### PR TITLE
fix: remove usage of fast-deep-equal

### DIFF
--- a/lib/resolvers.js
+++ b/lib/resolvers.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const deepEqual = require('fast-deep-equal')
+const { dequal: deepEqual } = require('dequal')
 const { MergeError } = require('./errors')
 
 function _arraysIntersection (arrays) {


### PR DESCRIPTION
Sorry! I missed this one when replacing `fast-deep-equal` with `dequal` (#3)

[This time it should be good](https://github.com/search?q=repo%3Afastify%2Fmerge-json-schemas%20fast-deep-equal&type=code)