### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
     "c8": "^8.0.1",
+    "eslint": "^9.17.0",
     "neostandard": "^0.11.9",
     "tsd": "^0.30.3"
   },


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.