### PR TITLE
feat: allow reusing resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Builds a logical conjunction (AND) of multiple [JSON schemas](https://json-schem
 
 #### resolvers
 
-A list of default resolvers that __merge-json-schema__ uses to merge JSON schemas. You can override the default resolvers by passing resolver functions against the keywords in the `options` argument of `mergeSchemas`. You may either pass in your own custom resolver functions or utilise the ones exposed via the `resolvers` object from the library. See [keywordResolver](#keywordresolver-keyword-values-mergedschema-parentschemas-options).
+A list of default resolvers that __merge-json-schema__ uses to merge JSON schemas. You can override the default resolvers by passing resolver functions against the keywords in the `options` argument of `mergeSchemas`. You may either pass in your own custom resolver functions or utilize the ones exposed via the `resolvers` object from the library. See [keywordResolver](#keywordresolver-keyword-values-mergedschema-parentschemas-options).
 
 __Example:__ Overriding the default resolver(intersection) with a union function for the `enum` keyword. 
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Builds a logical conjunction (AND) of multiple [JSON schemas](https://json-schem
 
 #### resolvers
 
-A list of default resolvers that __merge-json-schema__ uses to merge JSON schemas. You can override the default resolvers by passing a list of custom resolvers in the `options` argument of `mergeSchemas`. See [keywordResolver](#keywordresolver-keyword-values-mergedschema-parentschemas-options).
+A list of default resolvers that __merge-json-schema__ uses to merge JSON schemas. You can override the default resolvers by passing resolver functions against the keywords in the `options` argument of `mergeSchemas`. You may either use your own custom resolver functions or utilise the ones exposed as `resolvers` from the library. See [keywordResolver](#keywordresolver-keyword-values-mergedschema-parentschemas-options).
 
 #### defaultResolver
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,21 @@ Builds a logical conjunction (AND) of multiple [JSON schemas](https://json-schem
 
 #### resolvers
 
-A list of default resolvers that __merge-json-schema__ uses to merge JSON schemas. You can override the default resolvers by passing resolver functions against the keywords in the `options` argument of `mergeSchemas`. You may either use your own custom resolver functions or utilise the ones exposed as `resolvers` from the library. See [keywordResolver](#keywordresolver-keyword-values-mergedschema-parentschemas-options).
+A list of default resolvers that __merge-json-schema__ uses to merge JSON schemas. You can override the default resolvers by passing resolver functions against the keywords in the `options` argument of `mergeSchemas`. You may either pass in your own custom resolver functions or utilise the ones exposed via the `resolvers` object from the library. See [keywordResolver](#keywordresolver-keyword-values-mergedschema-parentschemas-options).
+
+__Example:__ Overriding the default resolver(intersection) with a union function for the `enum` keyword. 
+
+```javascript
+const schemaMerger = require('@fastify/merge-json-schemas');
+const mergedSchema = schemaMerger.mergeSchemas(
+    schemas,
+    {
+      resolvers: {
+        enum: schemaMerger.resolvers.arraysUnion
+      },
+    }
+);
+```
 
 #### defaultResolver
 

--- a/index.js
+++ b/index.js
@@ -353,4 +353,4 @@ function mergeSchemas (schemas, options = {}) {
   return _mergeSchemas(schemas, options)
 }
 
-module.exports = { mergeSchemas, keywordsResolvers, defaultResolver, ...errors }
+module.exports = { mergeSchemas, keywordsResolvers, defaultResolver, resolvers, ...errors }

--- a/test/exports.test.js
+++ b/test/exports.test.js
@@ -1,0 +1,22 @@
+const { resolvers } = require('../index')
+const assert = require('node:assert/strict')
+const { test } = require('node:test')
+
+test('Exported resolvers: should export all expected resolvers', () => {
+  assert(Object.prototype.hasOwnProperty.call(resolvers, 'arraysIntersection'))
+  assert(Object.prototype.hasOwnProperty.call(resolvers, 'hybridArraysIntersection'))
+  assert(Object.prototype.hasOwnProperty.call(resolvers, 'arraysUnion'))
+  assert(Object.prototype.hasOwnProperty.call(resolvers, 'minNumber'))
+  assert(Object.prototype.hasOwnProperty.call(resolvers, 'maxNumber'))
+  assert(Object.prototype.hasOwnProperty.call(resolvers, 'commonMultiple'))
+  assert(Object.prototype.hasOwnProperty.call(resolvers, 'allEqual'))
+  assert(Object.prototype.hasOwnProperty.call(resolvers, 'booleanAnd'))
+  assert(Object.prototype.hasOwnProperty.call(resolvers, 'booleanOr'))
+  assert(Object.prototype.hasOwnProperty.call(resolvers, 'skip'))
+})
+
+test('Exported resolvers: should ensure each resolver is a function', () => {
+  Object.values(resolvers).forEach((resolver) => {
+    assert.strictEqual(typeof resolver, 'function')
+  })
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -70,4 +70,4 @@ export const resolvers: {
   booleanAnd: KeywordResolver;
   booleanOr: KeywordResolver;
   skip: KeywordResolver;
-};
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -59,3 +59,15 @@ export function mergeSchemas (schemas: any[], options?: MergeOptions): any
 
 export const keywordsResolvers: KeywordResolvers
 export const defaultResolver: KeywordResolver
+export const resolvers: {
+  arraysIntersection: KeywordResolver;
+  hybridArraysIntersection: KeywordResolver;
+  arraysUnion: KeywordResolver;
+  minNumber: KeywordResolver;
+  maxNumber: KeywordResolver;
+  commonMultiple: KeywordResolver;
+  allEqual: KeywordResolver;
+  booleanAnd: KeywordResolver;
+  booleanOr: KeywordResolver;
+  skip: KeywordResolver;
+};

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,4 +1,4 @@
-import { mergeSchemas, MergeOptions } from '..'
+import { mergeSchemas, MergeOptions, resolvers, KeywordResolver } from '..'
 import { expectType } from 'tsd'
 
 {
@@ -50,3 +50,14 @@ import { expectType } from 'tsd'
 
   mergeSchemas([schema1, schema2], mergeOptions)
 }
+
+expectType<KeywordResolver>(resolvers.arraysIntersection)
+expectType<KeywordResolver>(resolvers.hybridArraysIntersection)
+expectType<KeywordResolver>(resolvers.arraysUnion)
+expectType<KeywordResolver>(resolvers.minNumber)
+expectType<KeywordResolver>(resolvers.maxNumber)
+expectType<KeywordResolver>(resolvers.commonMultiple)
+expectType<KeywordResolver>(resolvers.allEqual)
+expectType<KeywordResolver>(resolvers.booleanAnd)
+expectType<KeywordResolver>(resolvers.booleanOr)
+expectType<KeywordResolver>(resolvers.skip)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This PR exports resolver functions so we can reuse them. Let me give you an example:-

I wanted to use arraysUnion on _enum_ keyword. But the only option I had was to either 
1. Copy paste the _arraysUnion_ function & pass it in _mergeSchemas_ function. like

> const mergedSchema = schemaMerger.mergeSchemas([schema1,schema2], {
          resolvers: { 
            enum: CustomResolvers.arraysUnion
          }
          });

(here CustomResolvers is the module I created in my repo where I've copy pasted your _arraysUnion_ function)

2. Hacky reference import, because I know that _required_ is using arraysUnion as a resolver.
> const mergedSchema = schemaMerger.mergeSchemas([schema1, schema2], {
         resolvers: { 
            enum: schemaMerger.keywordsResolvers.required
         }
     } );

But now, after this change, on exporting resolvers, it makes your resolver functions re-usable. Hence I could do something like below, which is very intuitive and reduces boilerplate code for someone using the lib:-
> const mergedSchema = schemaMerger.mergeSchemas([schema1, schema2], {
         resolvers: { 
            enum: schemaMerger.resolvers.arraysUnion
         }
     } );

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
